### PR TITLE
 fixed the Verify and Decrypt examples which were using WithFooter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ During encoding process payload of type string and []byte is used without transf
 ## Use general parser to parse all supported token versions:
 ```go
 b, err := hex.DecodeString("2d2d2d2d2d424547494e205055424c4943204b45592d2d2d2d2d0d0a4d494942496a414e42676b71686b6947397730424151454641414f43415138414d49494243674b43415145417878636e47724e4f6136426c41523458707050640d0a746146576946386f7279746c4b534d6a66446831314c687956627a4335416967556b706a457274394d7649482f46384d444a72324f39486b36594b454b574b6f0d0a72333566364b6853303679357a714f722b7a4e34312b39626a52365633322b527345776d5a737a3038375258764e41334e687242633264593647736e57336c5a0d0a34356f5341564a755639553667335a334a574138355972362b6350776134793755632f56726f6d7a674679627355656e33476f724254626a783142384f514a440d0a73652f4b6b6855433655693358384264514f473974523455454775742f6c39703970732b3661474d4c57694357495a54615456784d4f75653133596b777038740d0a3148467635747a6872493055635948687638464a6b315a6435386759464158634e797975737834346e6a6152594b595948646e6b4f6a486e33416b534c4d306b0d0a6c774944415141420d0a2d2d2d2d2d454e44205055424c4943204b45592d2d2d2d2d")
-block, _ = pem.Decode(b)
+block, _ := pem.Decode(b)
 rsaPubInterface, err := x509.ParsePKIXPublicKey(block.Bytes)
 v1PublicKey := rsaPubInterface.(*rsa.PublicKey)
 
@@ -60,7 +60,7 @@ v2PublicKey := ed25519.PublicKey(b)
 
 var payload JSONToken
 var footer string
-version, err := paseto.Parse(token, &payload, &footer, symmetricKey, map[Version]crypto.PublicKey{V1: v1PublicKey, V2: v2PublicKey})
+version, err := paseto.Parse(token, &payload, &footer, symmetricKey, map[paseto.Version]crypto.PublicKey{paseto.V1: v1PublicKey, paseto.V2: v2PublicKey})
 ```
 
 ## Create token using symmetric key (local mode): 
@@ -86,7 +86,7 @@ footer := "some footer"
 v2 := paseto.NewV2()
 
 // Encrypt data
-token, err := v2.Encrypt(symmetricKey, jsonToken, WithFooter(footer))
+token, err := v2.Encrypt(symmetricKey, jsonToken, paseto.WithFooter(footer))
 // token = "v2.local.E42A2iMY9SaZVzt-WkCi45_aebky4vbSUJsfG45OcanamwXwieieMjSjUkgsyZzlbYt82miN1xD-X0zEIhLK_RhWUPLZc9nC0shmkkkHS5Exj2zTpdNWhrC5KJRyUrI0cupc5qrctuREFLAvdCgwZBjh1QSgBX74V631fzl1IErGBgnt2LV1aij5W3hw9cXv4gtm_jSwsfee9HZcCE0sgUgAvklJCDO__8v_fTY7i_Regp5ZPa7h0X0m3yf0n4OXY9PRplunUpD9uEsXJ_MTF5gSFR3qE29eCHbJtRt0FFl81x-GCsQ9H9701TzEjGehCC6Bhw.c29tZSBmb290ZXI"
 
 // Decrypt data
@@ -117,7 +117,7 @@ footer := "some footer"
 v2 := paseto.NewV2()
 
 // Sign data
-token, err := v2.Sign(privateKey, jsonToken, WithFooter(footer))
+token, err := v2.Sign(privateKey, jsonToken, paseto.WithFooter(footer))
 // token = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOC0wMy0xMlQxOTowODo1NCswMTowMCJ9Ojv0uXlUNXSFhR88KXb568LheLRdeGy2oILR3uyOM_-b7r7i_fX8aljFYUiF-MRr5IRHMBcWPtM0fmn9SOd6Aw.c29tZSBmb290ZXI"
 
 // Verify data

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ b, _ = hex.DecodeString("1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415
 v2PublicKey := ed25519.PublicKey(b)
 
 
-var payload JsonToken
+var payload JSONToken
 var footer string
-version, err := Parse(token, &payload, &footer, symmetricKey, map[Version]crypto.PublicKey{V1: v1PublicKey, V2: v2PublicKey})
+version, err := paseto.Parse(token, &payload, &footer, symmetricKey, map[Version]crypto.PublicKey{V1: v1PublicKey, V2: v2PublicKey})
 ```
 
 ## Create token using symmetric key (local mode): 
@@ -70,7 +70,7 @@ now := time.Now()
 exp := now.Add(24 * time.Hour)
 nbt := now
 
-jsonToken := JsonToken{
+jsonToken := paseto.JSONToken{
 		Audience:   "test",
 		Issuer:     "test_service",
 		Jti:        "123",
@@ -83,16 +83,16 @@ jsonToken := JsonToken{
 jsonToken.Set("data", "this is a signed message")
 footer := "some footer"
 
-v2 := NewV2()
+v2 := paseto.NewV2()
 
 // Encrypt data
 token, err := v2.Encrypt(symmetricKey, jsonToken, WithFooter(footer))
 // token = "v2.local.E42A2iMY9SaZVzt-WkCi45_aebky4vbSUJsfG45OcanamwXwieieMjSjUkgsyZzlbYt82miN1xD-X0zEIhLK_RhWUPLZc9nC0shmkkkHS5Exj2zTpdNWhrC5KJRyUrI0cupc5qrctuREFLAvdCgwZBjh1QSgBX74V631fzl1IErGBgnt2LV1aij5W3hw9cXv4gtm_jSwsfee9HZcCE0sgUgAvklJCDO__8v_fTY7i_Regp5ZPa7h0X0m3yf0n4OXY9PRplunUpD9uEsXJ_MTF5gSFR3qE29eCHbJtRt0FFl81x-GCsQ9H9701TzEjGehCC6Bhw.c29tZSBmb290ZXI"
 
 // Decrypt data
-var newJsonToken JsonToken
+var newJsonToken paseto.JSONToken
 var newFooter string
-err := v2.Decrypt(token, symmetricKey, &newJsonToken, WithFooter(&newFooter))
+err := v2.Decrypt(token, symmetricKey, &newJsonToken, &newFooter)
 ```
 
 ## Create token using asymetric key (public mode): 
@@ -103,7 +103,10 @@ privateKey := ed25519.PrivateKey(b)
 b, _ = hex.DecodeString("1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
 publicKey := ed25519.PublicKey(b)
 
-jsonToken := JsonToken{
+// or create a new keypair 
+// publicKey, privateKey, err := ed25519.GenerateKey(nil)
+
+jsonToken := paseto.JSONToken{
 		Expiration: time.Now().Add(24 * time.Hour),
 		}
 		
@@ -111,16 +114,16 @@ jsonToken := JsonToken{
 jsonToken.Set("data", "this is a signed message")
 footer := "some footer"
 
-v2 := NewV2()
+v2 := paseto.NewV2()
 
 // Sign data
 token, err := v2.Sign(privateKey, jsonToken, WithFooter(footer))
 // token = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOC0wMy0xMlQxOTowODo1NCswMTowMCJ9Ojv0uXlUNXSFhR88KXb568LheLRdeGy2oILR3uyOM_-b7r7i_fX8aljFYUiF-MRr5IRHMBcWPtM0fmn9SOd6Aw.c29tZSBmb290ZXI"
 
 // Verify data
-var newJsonToken JsonToken
+var newJsonToken paseto.JSONToken
 var newFooter string
-err := v2.Verify(token, publicKey, &newJsonToken, WithFooter(&newFooter))
+err := v2.Verify(token, publicKey, &newJsonToken, &newFooter)
 ```
 
 For more information see *_test.go files.


### PR DESCRIPTION
 fixed the Verify and Decrypt examples which were using WithFooter, renamed JsonToken to JSONToken and added the paseto package name to the examples to make it easier to use directly