### PR TITLE
Changes for 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,14 @@ matrix:
         - go test -v -race 
     - go: "1.12.x"
       script:
+        - go test -v -race
+    - go: "1.13.x"
+      script:
         - diff -u <(echo -n) <(goimports -d -s $(find . -type f -name '*.go' -not -path "./vendor/*"))
         - go vet $(go list ./... | grep -v /vendor/)
         - golint -set_exit_status
         - go test -v -race -coverprofile=paseto.coverprofile
-        - goveralls -coverprofile=paseto.coverprofile -service=travis-ci    
+        - goveralls -coverprofile=paseto.coverprofile -service=travis-ci
     - go: "tip"
       script:
         - diff -u <(echo -n) <(gofmt -d -s $(find . -type f -name '*.go' -not -path "./vendor/*"))

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,11 +1,10 @@
 package paseto
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"testing"
 	"time"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 // JSONToken

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,10 @@ require (
 	github.com/aead/chacha20poly1305 v0.0.0-20170617001512-233f39982aeb
 	github.com/aead/poly1305 v0.0.0-20180717145839-3fee0db0b635 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
 	golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/aead/poly1305 v0.0.0-20180717145839-3fee0db0b635 h1:52m0LGchQBBVqJRyY
 github.com/aead/poly1305 v0.0.0-20180717145839-3fee0db0b635/go.mod h1:lmLxL+FV291OopO93Bwf9fQLQeLyt33VJRUg5VJ30us=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/parser.go
+++ b/parser.go
@@ -4,9 +4,8 @@ package paseto
 
 import (
 	"crypto"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Version defines the token version.
@@ -73,9 +72,12 @@ func ParseFooter(token string, footer interface{}) error {
 	if len(parts) == 4 {
 		b, err := tokenEncoder.DecodeString(parts[3])
 		if err != nil {
-			return errors.Wrap(err, "failed to decode token")
+			return fmt.Errorf("failed to decode token: %w", err)
 		}
-		return errors.Wrap(fillValue(b, footer), "failed to decode footer")
+		if err = fillValue(b, footer); err != nil {
+			return fmt.Errorf("failed to decode footer: %w", err)
+		}
+		return nil
 	}
 	if len(parts) < 3 {
 		return ErrIncorrectTokenFormat

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,11 +2,11 @@ package paseto
 
 import (
 	"crypto"
+	"crypto/ed25519"
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestParse(t *testing.T) {

--- a/token_validator.go
+++ b/token_validator.go
@@ -1,9 +1,8 @@
 package paseto
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Validator defines a JSONToken validator function.
@@ -13,7 +12,7 @@ type Validator func(token *JSONToken) error
 func ForAudience(audience string) Validator {
 	return func(token *JSONToken) error {
 		if token.Audience != audience {
-			return errors.Wrapf(ErrTokenValidationError, `token was not intended for "%s" audience`, audience)
+			return fmt.Errorf(`token was not intended for "%s" audience: %w`, audience, ErrTokenValidationError)
 		}
 		return nil
 	}
@@ -23,7 +22,7 @@ func ForAudience(audience string) Validator {
 func IdentifiedBy(jti string) Validator {
 	return func(token *JSONToken) error {
 		if token.Jti != jti {
-			return errors.Wrapf(ErrTokenValidationError, `token was expected to be identified by "%s"`, jti)
+			return fmt.Errorf(`token was expected to be identified by "%s": %w`, jti, ErrTokenValidationError)
 		}
 		return nil
 	}
@@ -33,7 +32,7 @@ func IdentifiedBy(jti string) Validator {
 func IssuedBy(issuer string) Validator {
 	return func(token *JSONToken) error {
 		if token.Issuer != issuer {
-			return errors.Wrapf(ErrTokenValidationError, `token was not issued by "%s"`, issuer)
+			return fmt.Errorf(`token was not issued by "%s": %w`, issuer, ErrTokenValidationError)
 		}
 		return nil
 	}
@@ -43,7 +42,7 @@ func IssuedBy(issuer string) Validator {
 func Subject(subject string) Validator {
 	return func(token *JSONToken) error {
 		if token.Subject != subject {
-			return errors.Wrapf(ErrTokenValidationError, `token was not related to subject "%s"`, subject)
+			return fmt.Errorf(`token was not related to subject "%s": %w`, subject, ErrTokenValidationError)
 		}
 		return nil
 	}
@@ -54,13 +53,13 @@ func Subject(subject string) Validator {
 func ValidAt(t time.Time) Validator {
 	return func(token *JSONToken) error {
 		if !token.IssuedAt.IsZero() && t.Before(token.IssuedAt) {
-			return errors.Wrapf(ErrTokenValidationError, "token was issued in the future")
+			return fmt.Errorf("token was issued in the future: %w", ErrTokenValidationError)
 		}
 		if !token.NotBefore.IsZero() && t.Before(token.NotBefore) {
-			return errors.Wrapf(ErrTokenValidationError, "token cannot be used yet")
+			return fmt.Errorf("token cannot be used yet: %w", ErrTokenValidationError)
 		}
 		if !token.Expiration.IsZero() && t.After(token.Expiration) {
-			return errors.Wrapf(ErrTokenValidationError, "token has expired")
+			return fmt.Errorf("token has expired: %w", ErrTokenValidationError)
 		}
 		return nil
 	}

--- a/utils.go
+++ b/utils.go
@@ -5,10 +5,9 @@ import (
 	"crypto/sha512"
 	"encoding/binary"
 	"encoding/json"
-	"io"
-
-	"github.com/pkg/errors"
+	"fmt"
 	"golang.org/x/crypto/hkdf"
+	"io"
 )
 
 /*
@@ -67,13 +66,13 @@ func splitToken(token []byte, header []byte) (payload []byte, footer []byte, err
 
 	payload = make([]byte, tokenEncoder.DecodedLen(len(encodedPayload)))
 	if _, err = tokenEncoder.Decode(payload, encodedPayload); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to decode payload")
+		return nil, nil, fmt.Errorf("failed to decode payload: %w", err)
 	}
 
 	if encodedFooter != nil {
 		footer = make([]byte, tokenEncoder.DecodedLen(len(encodedFooter)))
 		if _, err = tokenEncoder.Decode(footer, encodedFooter); err != nil {
-			return nil, nil, errors.Wrap(err, "failed to decode footer")
+			return nil, nil, fmt.Errorf("failed to decode footer: %w", err)
 		}
 	}
 

--- a/v1.go
+++ b/v1.go
@@ -9,9 +9,8 @@ import (
 	"crypto/rsa"
 	"crypto/sha512"
 	"encoding/base64"
+	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -42,12 +41,12 @@ func NewV1() *V1 {
 func (p *V1) Encrypt(key []byte, payload interface{}, footer interface{}) (string, error) {
 	payloadBytes, err := infToByteArr(payload)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to encode payload to []byte")
+		return "", fmt.Errorf("failed to encode payload to []byte: %w", err)
 	}
 
 	footerBytes, err := infToByteArr(footer)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to encode footer to []byte")
+		return "", fmt.Errorf("failed to encode footer to []byte: %w", err)
 	}
 
 	var rndBytes []byte
@@ -57,24 +56,24 @@ func (p *V1) Encrypt(key []byte, payload interface{}, footer interface{}) (strin
 	} else {
 		rndBytes = make([]byte, nonceSize)
 		if _, err := io.ReadFull(rand.Reader, rndBytes); err != nil {
-			return "", errors.Wrap(err, "failed to read from rand.Reader")
+			return "", fmt.Errorf("failed to read from rand.Reader: %w", err)
 		}
 	}
 
 	macN := hmac.New(sha512.New384, rndBytes)
 	if _, err := macN.Write(payloadBytes); err != nil {
-		return "", errors.Wrap(err, "failed to hash payload")
+		return "", fmt.Errorf("failed to hash payload: %w", err)
 	}
 	nonce := macN.Sum(nil)[:32]
 
 	encKey, authKey, err := splitKey(key, nonce[:16])
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create enc and auth keys")
+		return "", fmt.Errorf("failed to create enc and auth keys: %w", err)
 	}
 
 	block, err := aes.NewCipher(encKey)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create aes cipher")
+		return "", fmt.Errorf("failed to create aes cipher: %w", err)
 	}
 
 	encryptedPayload := make([]byte, len(payloadBytes))
@@ -82,7 +81,7 @@ func (p *V1) Encrypt(key []byte, payload interface{}, footer interface{}) (strin
 
 	h := hmac.New(sha512.New384, authKey)
 	if _, err := h.Write(preAuthEncode(headerV1, nonce, encryptedPayload, footerBytes)); err != nil {
-		return "", errors.Wrap(err, "failed to create a signature")
+		return "", fmt.Errorf("failed to create a signature: %w", err)
 	}
 
 	mac := h.Sum(nil)
@@ -99,7 +98,7 @@ func (p *V1) Encrypt(key []byte, payload interface{}, footer interface{}) (strin
 func (p *V1) Decrypt(token string, key []byte, payload interface{}, footer interface{}) error {
 	data, footerBytes, err := splitToken([]byte(token), headerV1)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode token")
+		return fmt.Errorf("failed to decode token: %w", err)
 	}
 
 	if len(data) < nonceSize+macSize {
@@ -112,34 +111,34 @@ func (p *V1) Decrypt(token string, key []byte, payload interface{}, footer inter
 
 	encKey, authKey, err := splitKey(key, nonce[:16])
 	if err != nil {
-		return errors.Wrap(err, "failed to create enc and auth keys")
+		return fmt.Errorf("failed to create enc and auth keys: %w", err)
 	}
 
 	h := hmac.New(sha512.New384, authKey)
 	if _, err := h.Write(preAuthEncode(headerV1, nonce, encryptedPayload, footerBytes)); err != nil {
-		return errors.Wrap(err, "failed to create a signature")
+		return fmt.Errorf("failed to create a signature: %w", err)
 	}
 
 	if !hmac.Equal(h.Sum(nil), mac) {
-		return errors.Wrap(ErrInvalidTokenAuth, "failed to check token signature")
+		return fmt.Errorf("failed to check token signature: %w", ErrInvalidTokenAuth)
 	}
 
 	block, err := aes.NewCipher(encKey)
 	if err != nil {
-		return errors.Wrap(err, "failed to create aes cipher")
+		return fmt.Errorf("failed to create aes cipher: %w", err)
 	}
 	decryptedPayload := make([]byte, len(encryptedPayload))
 	cipher.NewCTR(block, nonce[16:]).XORKeyStream(decryptedPayload, encryptedPayload)
 
 	if payload != nil {
 		if err := fillValue(decryptedPayload, payload); err != nil {
-			return errors.Wrap(err, "failed to decode payload")
+			return fmt.Errorf("failed to decode payload: %w", err)
 		}
 	}
 
 	if footer != nil {
 		if err := fillValue(footerBytes, footer); err != nil {
-			return errors.Wrap(err, "failed to decode footer")
+			return fmt.Errorf("failed to decode footer: %w", err)
 		}
 	}
 
@@ -155,12 +154,12 @@ func (p *V1) Sign(privateKey crypto.PrivateKey, payload interface{}, footer inte
 
 	payloadBytes, err := infToByteArr(payload)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to encode payload to []byte")
+		return "", fmt.Errorf("failed to encode payload to []byte: %w", err)
 	}
 
 	footerBytes, err := infToByteArr(footer)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to encode footer to []byte")
+		return "", fmt.Errorf("failed to encode footer to []byte: %w", err)
 	}
 
 	var opts rsa.PSSOptions
@@ -169,13 +168,13 @@ func (p *V1) Sign(privateKey crypto.PrivateKey, payload interface{}, footer inte
 	sha384 := crypto.SHA384
 	pssHash := sha384.New()
 	if _, err := pssHash.Write(PSSMessage); err != nil {
-		return "", errors.Wrap(err, "failed to create pss hash")
+		return "", fmt.Errorf("failed to create pss hash: %w", err)
 	}
 	hashed := pssHash.Sum(nil)
 
 	signature, err := rsa.SignPSS(rand.Reader, rsaPrivateKey, sha384, hashed, &opts)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to sign token")
+		return "", fmt.Errorf("failed to sign token: %w", err)
 	}
 
 	body := append(payloadBytes, signature...)
@@ -192,11 +191,11 @@ func (p *V1) Verify(token string, publicKey crypto.PublicKey, payload interface{
 
 	data, footerBytes, err := splitToken([]byte(token), headerV1Public)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode token")
+		return fmt.Errorf("failed to decode token: %w", err)
 	}
 
 	if len(data) < v1SignSize {
-		return errors.Wrap(ErrIncorrectTokenFormat, "incorrect signature size")
+		return fmt.Errorf("incorrect signature size: %w", ErrIncorrectTokenFormat)
 	}
 
 	payloadBytes := data[:len(data)-v1SignSize]
@@ -208,7 +207,7 @@ func (p *V1) Verify(token string, publicKey crypto.PublicKey, payload interface{
 	sha384 := crypto.SHA384
 	pssHash := sha384.New()
 	if _, err := pssHash.Write(PSSMessage); err != nil {
-		return errors.Wrap(err, "failed to create pss hash")
+		return fmt.Errorf("failed to create pss hash: %w", err)
 	}
 	hashed := pssHash.Sum(nil)
 
@@ -218,13 +217,13 @@ func (p *V1) Verify(token string, publicKey crypto.PublicKey, payload interface{
 
 	if payload != nil {
 		if err := fillValue(payloadBytes, payload); err != nil {
-			return errors.Wrap(err, "failed to decode payload")
+			return fmt.Errorf("failed to decode payload: %w", err)
 		}
 	}
 
 	if footer != nil {
 		if err := fillValue(footerBytes, footer); err != nil {
-			return errors.Wrap(err, "failed to decode footer")
+			return fmt.Errorf("failed to decode footer: %w", err)
 		}
 	}
 

--- a/v1_test.go
+++ b/v1_test.go
@@ -7,9 +7,9 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -310,7 +310,7 @@ func TestPasetoV1_Decrypt_Error(t *testing.T) {
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			err := v1.Decrypt(test.token, symmetricKey, test.payload, test.footer)
-			assert.Equal(t, test.error, errors.Cause(err))
+			assert.True(t, errors.Is(err, test.error))
 		})
 	}
 }
@@ -377,7 +377,7 @@ func TestPasetoV1_Verify_Error(t *testing.T) {
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			err := v1.Verify(test.token, rsaPublicKey, test.payload, test.footer)
-			assert.Equal(t, test.error, errors.Cause(err))
+			assert.Equal(t, test.error, errors.Unwrap(err))
 		})
 	}
 }

--- a/v2_test.go
+++ b/v2_test.go
@@ -3,12 +3,12 @@ package paseto
 import (
 	"bytes"
 	"crypto"
+	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestPasetoV2_Encrypt_Compatibility(t *testing.T) {
@@ -236,7 +236,7 @@ func TestPasetoV2_Verify_Error(t *testing.T) {
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			err := v2.Verify(test.token, test.publicKey, test.payload, test.footer)
-			assert.Equal(t, test.error, errors.Cause(err))
+			assert.True(t, errors.Is(err, test.error))
 		})
 	}
 }
@@ -292,7 +292,7 @@ func TestPasetoV2_Decrypt_Error(t *testing.T) {
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
 			err := v2.Decrypt(test.token, symmetricKey, test.payload, test.footer)
-			assert.Equal(t, test.error, errors.Cause(err))
+			assert.True(t, errors.Is(err, test.error))
 		})
 	}
 }


### PR DESCRIPTION
Removed dependency on github.com/pkg/errors.
Updated golang.org/x/crypto/ed25519 to crypto/ed25519.
Updated test files.

These are api breaking changes, error checking and ed25519 code dependent on this version of paseto will need to be updated.