### PR TITLE
Keys with associated versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ During the encoding process, a payload of type string and []byte is used without
 
 ## Create token using symmetric key (local mode): 
 ```go
-symmetricKey := []byte("YELLOW SUBMARINE, BLACK WIZARDRY") // Must be 32 bytes
+symmetricKey := V2SymmetricKey{
+  material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY"), // Must be 32 bytes
+}
 now := time.Now()
 exp := now.Add(24 * time.Hour)
 nbt := now
@@ -198,10 +200,10 @@ err := paseto.Decrypt(token, symmetricKey, &newJsonToken, &newFooter)
 ## Create token using asymetric key (public mode): 
 ```go
 b, _ := hex.DecodeString("b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
-privateKey := ed25519.PrivateKey(b)
+privateKey := V2AsymmetricSecretKey{material: ed25519.PrivateKey(b)}
 
 b, _ = hex.DecodeString("1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
-publicKey := ed25519.PublicKey(b)
+publicKey := V2AsymmetricPublicKey{material: ed25519.PublicKey(b)}
 
 // or create a new keypair 
 // publicKey, privateKey, err := ed25519.GenerateKey(nil)
@@ -228,18 +230,36 @@ err := paseto.Verify(token, publicKey, &newJsonToken, &newFooter)
 **IMPORTANT**: Version 1 of the protocol is deprecated
 
 ```go
+v1SymmetricKey := V1SymmetricKey{
+  material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY"), // Must be 32 bytes
+}
+v2SymmetricKey := V2SymmetricKey{
+  material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY"), // Must be 32 bytes
+}
 b, err := hex.DecodeString("2d2d2d2d2d424547494e205055424c4943204b45592d2d2d2d2d0d0a4d494942496a414e42676b71686b6947397730424151454641414f43415138414d49494243674b43415145417878636e47724e4f6136426c41523458707050640d0a746146576946386f7279746c4b534d6a66446831314c687956627a4335416967556b706a457274394d7649482f46384d444a72324f39486b36594b454b574b6f0d0a72333566364b6853303679357a714f722b7a4e34312b39626a52365633322b527345776d5a737a3038375258764e41334e687242633264593647736e57336c5a0d0a34356f5341564a755639553667335a334a574138355972362b6350776134793755632f56726f6d7a674679627355656e33476f724254626a783142384f514a440d0a73652f4b6b6855433655693358384264514f473974523455454775742f6c39703970732b3661474d4c57694357495a54615456784d4f75653133596b777038740d0a3148467635747a6872493055635948687638464a6b315a6435386759464158634e797975737834346e6a6152594b595948646e6b4f6a486e33416b534c4d306b0d0a6c774944415141420d0a2d2d2d2d2d454e44205055424c4943204b45592d2d2d2d2d")
 block, _ := pem.Decode(b)
 rsaPubInterface, err := x509.ParsePKIXPublicKey(block.Bytes)
-v1PublicKey := rsaPubInterface.(*rsa.PublicKey)
+v1PublicKey := V1AsymmetricPublicKey{material: *rsaPubInterface.(*rsa.PublicKey)}
 
 b, _ = hex.DecodeString("1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
-v2PublicKey := ed25519.PublicKey(b)
+v2PublicKey := V2AsymmetricPublicKey{material: ed25519.PublicKey(b)}
 
 
 var payload JSONToken
 var footer string
-version, err := paseto.Parse(token, &payload, &footer, symmetricKey, map[paseto.Version]crypto.PublicKey{paseto.V1: v1PublicKey, paseto.V2: v2PublicKey})
+version, err := paseto.Parse(
+  token,
+  &payload,
+  &footer,
+  map[Version]SymmetricKey{
+    paseto.V1: v1SymmetricKey,
+    paseto.V2: v2SymmetricKey,
+  },
+  map[paseto.Version]AsymmetricPublicKey{
+    paseto.V1: v1PublicKey,
+    paseto.V2: v2PublicKey,
+  }
+)
 ```
 
 For more information see *_test.go files.

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -10,7 +10,7 @@ import (
 
 // JSONToken
 func Benchmark_V2_JSONToken_Encrypt(b *testing.B) {
-	symmetricKey := []byte("YELLOW SUBMARINE, BLACK WIZARDRY")
+	symmetricKey := V2SymmetricKey{material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY")}
 	now := time.Now()
 	exp := now.Add(24 * time.Hour)
 	nbt := now
@@ -36,7 +36,7 @@ func Benchmark_V2_JSONToken_Encrypt(b *testing.B) {
 }
 
 func Benchmark_V2_JSONToken_Decrypt(b *testing.B) {
-	symmetricKey := []byte("YELLOW SUBMARINE, BLACK WIZARDRY")
+	symmetricKey := V2SymmetricKey{material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY")}
 	//nolint:gosec
 	token := "v2.local.Ydp5u4gIRRR6u7Nvdb64qJs1W2wKSHNNEmi0LCnuZ9s-j74qrYu77tMzbUZvILPQE9Pl3OxPo246BUqQQ38YbZtQ2Stw8SJbvSbwF7npAjMkTx4leorq-bez8i9jLuyv7dHy8F4JaN8XxoNSpQdKI4Gn567sY-YxvBDTcEtM-VwRfe6vXHk_QG6pfil0hemk3zOAHPq0GxCA_uQnx6ggYN4mP_rqKdYV2P6Myf9nZmc-sw1hHCMSZegx6OH1nrKzvzMA9Y2ZO_tsg8IACz_wG2Mk.Zm9vdGVy"
 
@@ -53,7 +53,7 @@ func Benchmark_V2_JSONToken_Decrypt(b *testing.B) {
 
 func Benchmark_V2_JSONToken_Sign(b *testing.B) {
 	bb, _ := hex.DecodeString("b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
-	privateKey := ed25519.PrivateKey(bb)
+	privateKey := V2AsymmetricSecretKey{material: ed25519.PrivateKey(bb)}
 
 	now := time.Now()
 	exp := now.Add(24 * time.Hour)
@@ -82,7 +82,7 @@ func Benchmark_V2_JSONToken_Sign(b *testing.B) {
 func Benchmark_V2_JSONToken_Verify(b *testing.B) {
 	//nolint:gosec
 	bb, _ := hex.DecodeString("1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
-	publicKey := ed25519.PublicKey(bb)
+	publicKey := V2AsymmetricPublicKey{material: ed25519.PublicKey(bb)}
 	//nolint:gosec
 	token := "v2.public.eyJhdWQiOiJ0ZXN0IiwiZXhwIjoiMjAxOC0wMy0xMlQyMTo1Njo1MSswMTowMCIsImlhdCI6IjIwMTgtMDMtMTFUMjE6NTY6NTErMDE6MDAiLCJpc3MiOiJ0ZXN0X3NlcnZpY2UiLCJqdGkiOiIxMjMiLCJuYmYiOiIyMDE4LTAzLTExVDIxOjU2OjUxKzAxOjAwIiwic3ViIjoidGVzdF9zdWJqZWN0In24L0oWXbztBIdJYgAzsMqb2_0zDTNu65YRAOwn3Ux8tvepyynlYmAQB1yhvh6MIKl1BecuKmg1QzN2YRcGZi8O.Zm9vdGVy"
 
@@ -99,7 +99,7 @@ func Benchmark_V2_JSONToken_Verify(b *testing.B) {
 
 // String
 func Benchmark_V2_String_Encrypt(b *testing.B) {
-	symmetricKey := []byte("YELLOW SUBMARINE, BLACK WIZARDRY")
+	symmetricKey := V2SymmetricKey{material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY")}
 
 	const (
 		payload = "payload"
@@ -115,7 +115,7 @@ func Benchmark_V2_String_Encrypt(b *testing.B) {
 }
 
 func Benchmark_V2_String_Decrypt(b *testing.B) {
-	symmetricKey := []byte("YELLOW SUBMARINE, BLACK WIZARDRY")
+	symmetricKey := V2SymmetricKey{material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY")}
 	//nolint:gosec
 	token := "v2.local.VxvYfYL-KSCBaNC8toZUWgoqYHveHjypGx87pqUi0e69gKNAApe3sVkAog30zAc.Zm9vdGVy"
 
@@ -132,7 +132,7 @@ func Benchmark_V2_String_Decrypt(b *testing.B) {
 
 func Benchmark_V2_String_Sign(b *testing.B) {
 	bb, _ := hex.DecodeString("b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
-	privateKey := ed25519.PrivateKey(bb)
+	privateKey := V2AsymmetricSecretKey{material: ed25519.PrivateKey(bb)}
 
 	const (
 		payload = "payload"
@@ -149,7 +149,7 @@ func Benchmark_V2_String_Sign(b *testing.B) {
 
 func Benchmark_V2_String_Verify(b *testing.B) {
 	bb, _ := hex.DecodeString("1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2")
-	publicKey := ed25519.PublicKey(bb)
+	publicKey := V2AsymmetricPublicKey{material: ed25519.PublicKey(bb)}
 	//nolint:gosec
 	token := "v2.public.cGF5bG9hZP9crS7uGme2zSTkJ3kiamT0u6jN4qhKhiS0IWNi0sx-pS62QYJEHijhQGsCWRZ3JnoIBmLj6tawpN2Xd050pQg.Zm9vdGVy"
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,15 +1,13 @@
 package paseto
 
 import (
-	"crypto"
-	"encoding/hex"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func testEncryptDecrypt(t *testing.T, impl Protocol) {
+func testEncryptDecrypt(t *testing.T, impl Protocol, key SymmetricKey) {
 	t.Helper()
 	type Case struct {
 		payload         interface{}
@@ -17,8 +15,6 @@ func testEncryptDecrypt(t *testing.T, impl Protocol) {
 		obtainedPayload interface{}
 		obtainedFooter  interface{}
 	}
-
-	key, _ := hex.DecodeString("707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f")
 
 	cases := map[string]Case{
 		"struct payload, struct footer": {
@@ -66,7 +62,7 @@ func testEncryptDecrypt(t *testing.T, impl Protocol) {
 	})
 }
 
-func testSign(t *testing.T, impl Protocol, privateKey crypto.PrivateKey, publicKey crypto.PublicKey) {
+func testSign(t *testing.T, impl Protocol, privateKey AsymmetricSecretKey, publicKey AsymmetricPublicKey) {
 	t.Helper()
 
 	cases := map[string]struct {

--- a/json_token_test.go
+++ b/json_token_test.go
@@ -30,7 +30,7 @@ func (s StrInt) MarshalJSON() ([]byte, error) {
 }
 
 func TestJsonToken(t *testing.T) {
-	symmetricKey := []byte("YELLOW SUBMARINE, BLACK WIZARDRY")
+	symmetricKey := V2SymmetricKey{material: []byte("YELLOW SUBMARINE, BLACK WIZARDRY")}
 	const (
 		audience = "test audience"
 		issuer   = "test issuer"

--- a/protocol.go
+++ b/protocol.go
@@ -1,8 +1,6 @@
 package paseto
 
 import (
-	"crypto"
-
 	errors "golang.org/x/xerrors"
 )
 
@@ -11,12 +9,14 @@ var (
 	ErrUnsupportedTokenVersion = errors.New("unsupported parser version")
 	// ErrUnsupportedTokenType unsupported token type
 	ErrUnsupportedTokenType = errors.New("unsupported token type")
-	// ErrIncorrectPrivateKeyType incorrect private key type
-	ErrIncorrectPrivateKeyType = errors.New("incorrect private key type")
-	// ErrIncorrectPublicKeyType incorrect public key type
-	ErrIncorrectPublicKeyType = errors.New("incorrect public key type")
+	// ErrWrongKeyType incorrect key given for PASETO operation
+	ErrWrongKeyType = errors.New("the given key is not intended for this version of PASETO")
+	// ErrWrongKeyLength incorrect key given for PASETO operation
+	ErrWrongKeyLength = errors.New("the given key is the wrong length for this type of key")
 	// ErrPublicKeyNotFound public key for this version not found
 	ErrPublicKeyNotFound = errors.New("public key for this version not found")
+	// ErrSecretKeyNotFound public key for this version not found
+	ErrSecretKeyNotFound = errors.New("secret key for this version not found")
 	// ErrIncorrectTokenFormat incorrect token format
 	ErrIncorrectTokenFormat = errors.New("incorrect token format")
 	// ErrIncorrectTokenHeader incorrect token header
@@ -31,22 +31,47 @@ var (
 	ErrTokenValidationError = errors.New("token validation error")
 )
 
+type SymmetricKey interface {
+
+	// Encrypt encrypts a token with a symmetric key. The key should be a byte
+	// slice of 32 bytes, regardless of whether PASETO v1 or v2 is being used.
+	encrypt(payload interface{}, footer interface{}, unitTestNonce []byte) (string, error)
+
+	// Decrypt decrypts a token which was encrypted with a symmetric key.
+	decrypt(token string, payload interface{}, footer interface{}) error
+}
+
+type AsymmetricSecretKey interface {
+
+	// Sign signs a token with the given private key. For PASETO v1, the key should
+	// be an rsa.PrivateKey. For v2, the key should be an ed25519.PrivateKey.
+	sign(payload interface{}, footer interface{}) (string, error)
+}
+
+type AsymmetricPublicKey interface {
+
+	// Verify verifies a token against the given public key. For PASETO v1, the key
+	// key should be an rsa.PublicKey. For v2, the key should be an
+	// ed25519.PublicKey.
+	verify(token string, value interface{}, footer interface{}) error
+}
+
 // Protocol defines the PASETO token protocol interface.
 type Protocol interface {
 
 	// Encrypt encrypts a token with a symmetric key. The key should be a byte
 	// slice of 32 bytes, regardless of whether PASETO v1 or v2 is being used.
-	Encrypt(key []byte, payload interface{}, footer interface{}) (string, error)
+	Encrypt(key SymmetricKey, payload interface{}, footer interface{}) (string, error)
 
 	// Decrypt decrypts a token which was encrypted with a symmetric key.
-	Decrypt(token string, key []byte, payload interface{}, footer interface{}) error
+	Decrypt(token string, key SymmetricKey, payload interface{}, footer interface{}) error
 
 	// Sign signs a token with the given private key. For PASETO v1, the key should
 	// be an rsa.PrivateKey. For v2, the key should be an ed25519.PrivateKey.
-	Sign(privateKey crypto.PrivateKey, payload interface{}, footer interface{}) (string, error)
+	Sign(privateKey AsymmetricSecretKey, payload interface{}, footer interface{}) (string, error)
 
 	// Verify verifies a token against the given public key. For PASETO v1, the key
 	// key should be an rsa.PublicKey. For v2, the key should be an
 	// ed25519.PublicKey.
-	Verify(token string, publicKey crypto.PublicKey, value interface{}, footer interface{}) error
+	Verify(token string, publicKey AsymmetricPublicKey, value interface{}, footer interface{}) error
 }

--- a/utils.go
+++ b/utils.go
@@ -2,12 +2,9 @@ package paseto
 
 import (
 	"bytes"
-	"crypto/sha512"
 	"encoding/binary"
 	"encoding/json"
-	"io"
 
-	"golang.org/x/crypto/hkdf"
 	errors "golang.org/x/xerrors"
 )
 
@@ -27,21 +24,6 @@ func preAuthEncode(pieces ...[]byte) []byte {
 		buf.Write(p)
 	}
 	return buf.Bytes()
-}
-
-func splitKey(key, salt []byte) (encKey, authKey []byte, err error) {
-	eReader := hkdf.New(sha512.New384, key, salt, []byte("paseto-encryption-key"))
-	aReader := hkdf.New(sha512.New384, key, salt, []byte("paseto-auth-key-for-aead"))
-	encKey = make([]byte, 32)
-	authKey = make([]byte, 32)
-	if _, err = io.ReadFull(eReader, encKey); err != nil {
-		return nil, nil, err
-	}
-	if _, err = io.ReadFull(aReader, authKey); err != nil {
-		return nil, nil, err
-	}
-
-	return encKey, authKey, nil
 }
 
 func splitToken(token, header []byte) (payload, footer []byte, err error) {

--- a/v2.go
+++ b/v2.go
@@ -1,7 +1,6 @@
 package paseto
 
 import (
-	"crypto"
 	"crypto/rand"
 	"io"
 
@@ -14,7 +13,10 @@ import (
 const (
 	v2SignSize = ed25519.SignatureSize
 	// XNonceSize is the size of the XChaCha20 nonce in bytes.
-	XNonceSize = 24
+	XNonceSize                = 24
+	v2SymmetricKeySize        = 32
+	v2AsymmetricSecretKeySize = 64
+	v2AsymmetricPublicKeySize = 32
 )
 
 var headerV2 = []byte("v2.local.")
@@ -31,8 +33,76 @@ type V2 struct {
 	nonce []byte
 }
 
+// V2SymmetricKey Version 2 Symmetric Key
+type V2SymmetricKey struct {
+	material []byte
+}
+
+// V2AsymmetricSecretKey Version 2 Private Key
+type V2AsymmetricSecretKey struct {
+	material ed25519.PrivateKey
+}
+
+// Public returns the public key corresponding to priv.
+func (k V2AsymmetricSecretKey) Public() V2AsymmetricPublicKey {
+	return V2AsymmetricPublicKey{material: k.material.Public().(ed25519.PublicKey)}
+}
+
+// V2AsymmetricPublicKey Version 2 Public Key
+type V2AsymmetricPublicKey struct {
+	material ed25519.PublicKey
+}
+
 // Encrypt implements Protocol.Encrypt
-func (p *V2) Encrypt(key []byte, payload, footer interface{}) (string, error) {
+func (p *V2) Encrypt(key SymmetricKey, payload, footer interface{}) (string, error) {
+	v2SymmetricKey, ok := key.(V2SymmetricKey)
+
+	if !ok {
+		return "", ErrWrongKeyType
+	}
+
+	return v2SymmetricKey.encrypt(payload, footer, p.nonce)
+}
+
+// Decrypt implements Protocol.Decrypt
+func (p *V2) Decrypt(token string, key SymmetricKey, payload, footer interface{}) error {
+	v2SymmetricKey, ok := key.(V2SymmetricKey)
+
+	if !ok {
+		return ErrWrongKeyType
+	}
+
+	return v2SymmetricKey.decrypt(token, payload, footer)
+}
+
+// Sign implements Protocol.Sign. privateKey should be of type *rsa.PrivateKey
+func (p *V2) Sign(privateKey AsymmetricSecretKey, payload, footer interface{}) (string, error) {
+	v2SecretKey, ok := privateKey.(V2AsymmetricSecretKey)
+
+	if !ok {
+		return "", ErrWrongKeyType
+	}
+
+	return v2SecretKey.sign(payload, footer)
+}
+
+// Verify implements Protocol.Verify. publicKey should be of type *rsa.PublicKey
+func (p *V2) Verify(token string, publicKey AsymmetricPublicKey, payload, footer interface{}) error {
+	v2PublicKey, ok := publicKey.(V2AsymmetricPublicKey)
+
+	if !ok {
+		return ErrWrongKeyType
+	}
+
+	return v2PublicKey.verify(token, payload, footer)
+}
+
+// encrypt implements SymmetricKey.encrypt
+func (k V2SymmetricKey) encrypt(payload, footer interface{}, unitTestNonce []byte) (string, error) {
+	if len(k.material) != v2SymmetricKeySize {
+		return "", ErrWrongKeyLength
+	}
+
 	payloadBytes, err := infToByteArr(payload)
 	if err != nil {
 		return "", errors.Errorf("failed to encode payload to []byte: %w", err)
@@ -45,8 +115,8 @@ func (p *V2) Encrypt(key []byte, payload, footer interface{}) (string, error) {
 
 	var rndBytes []byte
 
-	if p.nonce != nil {
-		rndBytes = p.nonce
+	if unitTestNonce != nil {
+		rndBytes = unitTestNonce
 	} else {
 		rndBytes = make([]byte, XNonceSize)
 		if _, err := io.ReadFull(rand.Reader, rndBytes); err != nil { //nolint:govet
@@ -64,7 +134,7 @@ func (p *V2) Encrypt(key []byte, payload, footer interface{}) (string, error) {
 
 	nonce := hash.Sum(nil)
 
-	aead, err := chacha20poly1305.NewX(key)
+	aead, err := chacha20poly1305.NewX(k.material[:])
 	if err != nil {
 		return "", errors.Errorf("failed to create chacha20poly1305 cipher: %w", err)
 	}
@@ -74,8 +144,12 @@ func (p *V2) Encrypt(key []byte, payload, footer interface{}) (string, error) {
 	return createToken(headerV2, append(nonce, encryptedPayload...), footerBytes), nil
 }
 
-// Decrypt implements Protocol.Decrypt
-func (*V2) Decrypt(token string, key []byte, payload, footer interface{}) error {
+// decrypt implements SymmetricKey.decrypt
+func (k V2SymmetricKey) decrypt(token string, payload interface{}, footer interface{}) error {
+	if len(k.material) != v2SymmetricKeySize {
+		return ErrWrongKeyLength
+	}
+
 	body, footerBytes, err := splitToken([]byte(token), headerV2)
 	if err != nil {
 		return errors.Errorf("failed to decode token: %w", err)
@@ -88,7 +162,7 @@ func (*V2) Decrypt(token string, key []byte, payload, footer interface{}) error 
 	nonce := body[:XNonceSize]
 	encryptedPayload := body[XNonceSize:]
 
-	aead, err := chacha20poly1305.NewX(key)
+	aead, err := chacha20poly1305.NewX(k.material)
 	if err != nil {
 		return errors.Errorf("failed to create chacha20poly1305 cipher: %w", err)
 	}
@@ -112,11 +186,10 @@ func (*V2) Decrypt(token string, key []byte, payload, footer interface{}) error 
 	return nil
 }
 
-// Sign implements Protocol.Sign
-func (*V2) Sign(privateKey crypto.PrivateKey, payload, footer interface{}) (string, error) {
-	key, ok := privateKey.(ed25519.PrivateKey)
-	if !ok {
-		return "", ErrIncorrectPrivateKeyType
+// sign implements AsymmetricSecretKey.sign
+func (k V2AsymmetricSecretKey) sign(payload, footer interface{}) (string, error) {
+	if len(k.material) != v2AsymmetricSecretKeySize {
+		return "", ErrWrongKeyLength
 	}
 
 	payloadBytes, err := infToByteArr(payload)
@@ -129,16 +202,15 @@ func (*V2) Sign(privateKey crypto.PrivateKey, payload, footer interface{}) (stri
 		return "", errors.Errorf("failed to encode footer to []byte: %w", err)
 	}
 
-	sig := ed25519.Sign(key, preAuthEncode(headerV2Public, payloadBytes, footerBytes))
+	sig := ed25519.Sign(k.material, preAuthEncode(headerV2Public, payloadBytes, footerBytes))
 
 	return createToken(headerV2Public, append(payloadBytes, sig...), footerBytes), nil
 }
 
-// Verify implements Protocol.Verify
-func (*V2) Verify(token string, publicKey crypto.PublicKey, payload, footer interface{}) error {
-	pub, ok := publicKey.(ed25519.PublicKey)
-	if !ok {
-		return ErrIncorrectPublicKeyType
+// verify implements AsymmetricPublicKey.verify
+func (k V2AsymmetricPublicKey) verify(token string, payload, footer interface{}) error {
+	if len(k.material) != v2AsymmetricPublicKeySize {
+		return ErrWrongKeyLength
 	}
 
 	data, footerBytes, err := splitToken([]byte(token), headerV2Public)
@@ -153,7 +225,7 @@ func (*V2) Verify(token string, publicKey crypto.PublicKey, payload, footer inte
 	payloadBytes := data[:len(data)-v2SignSize]
 	signature := data[len(data)-v2SignSize:]
 
-	if !ed25519.Verify(pub, preAuthEncode(headerV2Public, payloadBytes, footerBytes), signature) {
+	if !ed25519.Verify(k.material, preAuthEncode(headerV2Public, payloadBytes, footerBytes), signature) {
 		return ErrInvalidSignature
 	}
 


### PR DESCRIPTION
As alluded to in #32, keys should to be strongly bound to their parameter choices to prevent algorithm confusion attacks (so byte arrays or similar shouldn't be accepted). From the PASETO spec:

> # PASETO Cryptography Key Requirements
> Cryptography keys in PASETO are defined as **both the raw key material and its parameter choices, not just the raw key material.**
>
> PASETO implementations **MUST** enforce some logical separation between different key types; especially when the raw key material is the same (i.e. a 256-bit opaque blob).
>
> Arbitrary strings (or byte arrays, or equivalent language constructs) **MUST NOT** be accepted as a key in any PASETO library, [...]

I've opted to refactor the core PASETO operations into methods associated with each specific key (e.g. `V2SymmetricKey` has implementations for `encrypt`, `decrypt` involving its raw material). This means that the version level methods just need to do a type assertion checking that the given key matches the version, before deferring down to the key specific implementation.

Fixes #32 